### PR TITLE
OneBroker API: throw exception if API returned error

### DIFF
--- a/app/Util/OneBroker.php
+++ b/app/Util/OneBroker.php
@@ -152,7 +152,7 @@ class OneBroker {
             error_log('STATUS CODE', $statusCode . ' ' . $response);
         }
 
-        $body = json_decode($response,1);
+        $body = json_decode($response, 1);
         
         if ($body['error'] === true) {
             throw new \RuntimeException(
@@ -160,7 +160,7 @@ class OneBroker {
             );
         }
         
-        return array( "statusCode" => $statusCode, "body" => json_decode($response,1));
+        return array( "statusCode" => $statusCode, "body" => $body);
     }
 
     /**

--- a/app/Util/OneBroker.php
+++ b/app/Util/OneBroker.php
@@ -152,6 +152,14 @@ class OneBroker {
             error_log('STATUS CODE', $statusCode . ' ' . $response);
         }
 
+        $body = json_decode($response,1);
+        
+        if ($body['error'] === true) {
+            throw new \RuntimeException(
+                sprintf('OneBroker API returned an error - %d: %s', $body['error_code'], $body['error_message'])
+            );
+        }
+        
         return array( "statusCode" => $statusCode, "body" => json_decode($response,1));
     }
 


### PR DESCRIPTION
This will show an error message to the user and will stop script execution. This also preventing saving errors to cache
Example: OneBroker API returned an error - 201: Invalid token. You are not logged in.