### PR TITLE
30m ohlc data not actually 30m

### DIFF
--- a/app/Scripts/DBdump-0.1.sql
+++ b/app/Scripts/DBdump-0.1.sql
@@ -1,0 +1,15 @@
+-- Only import this file if you have already imported the previous DBdump file before 8/8/17 - Create syntax for TABLE 'bowhead_ohlc_tick'
+CREATE TABLE `bowhead_ohlc_tick` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `instrument` varchar(10) DEFAULT NULL,
+  `ctime` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `timeid` bigint(28) DEFAULT NULL,
+  `open` float DEFAULT NULL,
+  `high` float DEFAULT NULL,
+  `low` float DEFAULT NULL,
+  `close` float DEFAULT NULL,
+  `volume` int(18) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `instrument` (`instrument`,`timeid`),
+  KEY `ctime` (`ctime`)
+) ENGINE=InnoDB AUTO_INCREMENT=78080 DEFAULT CHARSET=utf8;

--- a/app/Scripts/DBdump.sql
+++ b/app/Scripts/DBdump.sql
@@ -329,6 +329,22 @@ CREATE TABLE `bowhead_ohlc_5m` (
   KEY `ctime` (`ctime`)
 ) ENGINE=InnoDB AUTO_INCREMENT=78080 DEFAULT CHARSET=utf8;
 
+-- Create syntax for TABLE 'bowhead_ohlc_tick'
+CREATE TABLE `bowhead_ohlc_tick` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `instrument` varchar(10) DEFAULT NULL,
+  `ctime` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `timeid` bigint(28) DEFAULT NULL,
+  `open` float DEFAULT NULL,
+  `high` float DEFAULT NULL,
+  `low` float DEFAULT NULL,
+  `close` float DEFAULT NULL,
+  `volume` int(18) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `instrument` (`instrument`,`timeid`),
+  KEY `ctime` (`ctime`)
+) ENGINE=InnoDB AUTO_INCREMENT=78080 DEFAULT CHARSET=utf8;
+
 -- Create syntax for TABLE 'bowhead_strategy'
 CREATE TABLE `bowhead_strategy` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,

--- a/app/Traits/OHLC.php
+++ b/app/Traits/OHLC.php
@@ -50,10 +50,10 @@ trait OHLC
 
         /** 1m table update **/
 
-	$open1 = null;
-	$close1 = null;
-	$high1 = null;
-	$low1 = null;
+        $open1 = null;
+        $close1 = null;
+        $high1 = null;
+        $low1 = null;
 
         $timeid = date("YmdHi", strtotime($timeid));
 
@@ -80,7 +80,7 @@ trait OHLC
                 $high1 = $accum1a->high;
                 $low1 = $accum1a->low;
             }
-            
+
 
             /* Get Open price from ticker data and last minute */
             $accum1mb = \DB::table('bowhead_ohlc_tick')->select(DB::raw('open AS open'))
@@ -105,10 +105,10 @@ trait OHLC
 
             foreach ($accum1mc as $accum1c) {
                 $close1 = $accum1c->close;
-            }            
-	   
+            }
 
-	    if ($open1 && $close1 && $high1 && $low1) {
+
+            if ($open1 && $close1 && $high1 && $low1) {
                 $ins = \DB::insert("
             INSERT INTO bowhead_ohlc_1m 
             (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
@@ -126,10 +126,10 @@ trait OHLC
 
         /** 5m table update  **/
 
-	$open5 = null;
-	$close5 = null;
-	$high5 = null;
-	$low5 = null;
+        $open5 = null;
+        $close5 = null;
+        $high5 = null;
+        $low5 = null;
 
         $last5m = \DB::table('bowhead_ohlc_5m')->select(DB::raw('MAX(timeid) AS timeid'))
             ->where('instrument', $bf_pair)

--- a/app/Traits/OHLC.php
+++ b/app/Traits/OHLC.php
@@ -16,9 +16,9 @@ trait OHLC
      *
      * @return bool
      */
-    public function markOHLC($ticker, $bf=false, $bf_pair='BTC/USD')
+    public function markOHLC($ticker, $bf = false, $bf_pair = 'BTC/USD')
     {
-        $timeid = date('YmdHi'); // 201705301522 unique for date
+        $timeid = date('YmdHis'); // 20170530152259 unique for date
         if ($bf) {
             /** Bitfinex websocked */
             $last_price = $ticker[7];
@@ -35,116 +35,350 @@ trait OHLC
             $volume = 0;
         }
 
-        /** 1m table update **/
-        //echo date("Y-m-d h:i:sa")."\n".print_r($ticker);
-        $last1m = \DB::table('bowhead_ohlc_1m')->select(DB::raw('MAX(timeid) AS timeid'))
-            ->where('instrument', $bf_pair)
-            ->get();
-        foreach ($last1m as $last1) {
-            $last1timeid = $last1->timeid;
-	    $last1timeid = date("YmdHi", strtotime("+1 minutes", strtotime($last1timeid)));		
-        }
-        if ($last1timeid = $timeid) {
-            $ins = \DB::insert("
-            INSERT INTO bowhead_ohlc_1m 
+        /** tick table update */
+        $ins = \DB::insert("
+            INSERT INTO bowhead_ohlc_tick
             (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
             VALUES
             ('$instrument', $timeid, $last_price, $last_price, $last_price, $last_price, $volume)
+            ON DUPLICATE KEY UPDATE
+            `high`   = CASE WHEN `high` < VALUES(`high`) THEN VALUES(`high`) ELSE `high` END,
+            `low`    = CASE WHEN `low` > VALUES(`low`) THEN VALUES(`low`) ELSE `low` END,
+            `volume` = VALUES(`volume`),
+            `close`  = VALUES(`close`)
+        ");
+
+        /** 1m table update **/
+
+	$open1 = null;
+	$close1 = null;
+	$high1 = null;
+	$low1 = null;
+
+        $timeid = date("YmdHi", strtotime($timeid));
+
+        $last1m = \DB::table('bowhead_ohlc_1m')->select(DB::raw('MAX(timeid) AS timeid'))
+            ->where('instrument', $bf_pair)
+            ->get();
+
+        foreach ($last1m as $last1) {
+            $last1timeid = $last1->timeid;
+            $last1timeid = date("YmdHi", strtotime($last1timeid));
+        }
+
+        if ($last1timeid < $timeid) {
+
+            /* Get High and Low from ticker data for insertion */
+            $last1timeids = date("YmdHis", strtotime(date("YmdHi", strtotime("-1 minutes", strtotime("now")))));
+            $accum1ma = \DB::table('bowhead_ohlc_tick')->select(DB::raw('MAX(high) as high, MIN(low) as low'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last1timeids)
+                ->where('timeid', '<=', ($last1timeids + 59))
+                ->get();
+
+            foreach ($accum1ma as $accum1a) {
+                $high1 = $accum1a->high;
+                $low1 = $accum1a->low;
+            }
+            
+
+            /* Get Open price from ticker data and last minute */
+            $accum1mb = \DB::table('bowhead_ohlc_tick')->select(DB::raw('open AS open'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last1timeids)
+                ->where('timeid', '<=', ($last1timeids + 59))
+                ->limit(1)
+                ->get();
+
+            foreach ($accum1mb as $accum1b) {
+                $open1 = $accum1b->open;
+            }
+
+            /* Get close price from ticker data and last minute */
+            $accum1mc = \DB::table('bowhead_ohlc_tick')->select(DB::raw('close AS close'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last1timeids)
+                ->where('timeid', '<=', ($last1timeids + 59))
+                ->orderBy('ctime', 'desc')
+                ->limit(1)
+                ->get();
+
+            foreach ($accum1mc as $accum1c) {
+                $close1 = $accum1c->close;
+            }            
+	   
+
+	    if ($open1 && $close1 && $high1 && $low1) {
+                $ins = \DB::insert("
+            INSERT INTO bowhead_ohlc_1m 
+            (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
+            VALUES
+            ('$instrument', $timeid, $open1, $high1, $low1, $close1, $volume)
             ON DUPLICATE KEY UPDATE 
             `high`   = CASE WHEN `high` < VALUES(`high`) THEN VALUES(`high`) ELSE `high` END,
             `low`    = CASE WHEN `low` > VALUES(`low`) THEN VALUES(`low`) ELSE `low` END,
             `volume` = VALUES(`volume`),
             `close`  = VALUES(`close`)
         ");
+            }
+
         }
 
         /** 5m table update  **/
+
+	$open5 = null;
+	$close5 = null;
+	$high5 = null;
+	$low5 = null;
 
         $last5m = \DB::table('bowhead_ohlc_5m')->select(DB::raw('MAX(timeid) AS timeid'))
             ->where('instrument', $bf_pair)
             ->get();
         foreach ($last5m as $last5) {
             $last5timeid = $last5->timeid;
-	    $last5timeid = date("YmdHi", strtotime("+4 minutes", strtotime($last5timeid)));
+            $last5timeid = date("YmdHi", strtotime("+4 minutes", strtotime($last5timeid)));
         }
         if ($last5timeid < $timeid) {
-            $ins = \DB::insert("
+            /* Get High and Low from 1m data for insertion */
+            $last5timeids = date("YmdHi", strtotime("-5 minutes", strtotime("now")));
+            $accum5ma = \DB::table('bowhead_ohlc_1m')->select(DB::raw('MAX(high) as high, MIN(low) as low'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last5timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->get();
+
+            foreach ($accum5ma as $accum5a) {
+                $high5 = $accum5a->high;
+                $low5 = $accum5a->low;
+            }
+
+            /* Get Open price from 1m data and last 5 minutes */
+            $accum5mb = \DB::table('bowhead_ohlc_1m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last5timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->limit(1)
+                ->get();
+            foreach ($accum5mb as $accum5b) {
+                $open5 = $accum5b->open;
+            }
+
+            /* Get Close price from 1m data and last 5 minutes */
+            $accum5mc = \DB::table('bowhead_ohlc_1m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last5timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->orderBy('ctime', 'desc')
+                ->limit(1)
+                ->get();
+            foreach ($accum5mc as $accum5c) {
+                $close5 = $accum5c->close;
+            }
+            if ($open5 && $close5 && $low5 && $high5) {
+                $ins = \DB::insert("
             INSERT INTO bowhead_ohlc_5m 
             (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
             VALUES
-            ('$instrument', $timeid, $last_price, $last_price, $last_price, $last_price, $volume)
+            ('$instrument', $timeid, $open5, $high5, $low5, $close5, $volume)
             ON DUPLICATE KEY UPDATE 
             `high`   = CASE WHEN `high` < VALUES(`high`) THEN VALUES(`high`) ELSE `high` END,
             `low`    = CASE WHEN `low` > VALUES(`low`) THEN VALUES(`low`) ELSE `low` END,
             `volume` = VALUES(`volume`),
             `close`  = VALUES(`close`)
         ");
+            }
         }
 
         /** 15m table update **/
+        $open15 = null;
+        $close15 = null;
+        $high15 = null;
+        $low15 = null;
+
         $last15m = \DB::table('bowhead_ohlc_15m')->select(DB::raw('MAX(timeid) AS timeid'))
             ->where('instrument', $bf_pair)
             ->get();
         foreach ($last15m as $last15) {
             $last15timeid = $last15->timeid;
-	    $last15timeid = date("YmdHi", strtotime("+14 minutes", strtotime($last15timeid)));	    
+            $last15timeid = date("YmdHi", strtotime("+14 minutes", strtotime($last15timeid)));
         }
         if ($last15timeid < $timeid) {
-            $ins = \DB::insert("
+            /* Get High and Low from 5m data for insertion */
+            $last15timeids = date("YmdHi", strtotime("-15 minutes", strtotime("now")));
+            $accum15ma = \DB::table('bowhead_ohlc_5m')->select(DB::raw('MAX(high) as high, MIN(low) as low'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last15timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->get();
+
+            foreach ($accum15ma as $accum15a) {
+                $high15 = $accum15a->high;
+                $low15 = $accum15a->low;
+            }
+
+            /* Get Open price from 5m data and last 15 minutes */
+            $accum15mb = \DB::table('bowhead_ohlc_5m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last15timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->limit(1)
+                ->get();
+            foreach ($accum15mb as $accum15b) {
+                $open15 = $accum15b->open;
+            }
+
+            /* Get Close price from 5m data and last 15 minutes */
+            $accum15mc = \DB::table('bowhead_ohlc_5m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last15timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->orderBy('ctime', 'desc')
+                ->limit(1)
+                ->get();
+            foreach ($accum15mc as $accum15c) {
+                $close15 = $accum15c->close;
+            }
+            if ($open15 && $close15 && $low15 && $high15) {
+                $ins = \DB::insert("
             INSERT INTO bowhead_ohlc_15m 
             (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
             VALUES
-            ('$instrument', $timeid, $last_price, $last_price, $last_price, $last_price, $volume)
+            ('$instrument', $timeid, $open15, $high15, $low15, $close15, $volume)
             ON DUPLICATE KEY UPDATE 
             `high`   = CASE WHEN `high` < VALUES(`high`) THEN VALUES(`high`) ELSE `high` END,
             `low`    = CASE WHEN `low` > VALUES(`low`) THEN VALUES(`low`) ELSE `low` END,
             `volume` = VALUES(`volume`),
             `close`  = VALUES(`close`)
         ");
+            }
         }
 
         /** 30m table update **/
+        $open30 = null;
+        $close30 = null;
+        $high30 = null;
+        $low30 = null;
+
         $last30m = \DB::table('bowhead_ohlc_30m')->select(DB::raw('MAX(timeid) AS timeid'))
             ->where('instrument', $bf_pair)
             ->get();
         foreach ($last30m as $last30) {
             $last30timeid = $last30->timeid;
-	    $last30timeid = date("YmdHi", strtotime("+29 minutes", strtotime($last30timeid)));
+            $last30timeid = date("YmdHi", strtotime("+29 minutes", strtotime($last30timeid)));
         }
         if ($last30timeid < $timeid) {
-            $ins = \DB::insert("
+            /* Get High and Low from 15m data for insertion */
+            $last30timeids = date("YmdHi", strtotime("-30 minutes", strtotime("now")));
+            $accum30ma = \DB::table('bowhead_ohlc_15m')->select(DB::raw('MAX(high) as high, MIN(low) as low'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last30timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->get();
+
+            foreach ($accum30ma as $accum30a) {
+                $high30 = $accum30a->high;
+                $low30 = $accum30a->low;
+            }
+
+            /* Get Open price from 15m data and last 30 minutes */
+            $accum30mb = \DB::table('bowhead_ohlc_15m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last30timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->limit(1)
+                ->get();
+            foreach ($accum30mb as $accum30b) {
+                $open30 = $accum30b->open;
+            }
+
+            /* Get Close price from 15m data and last 30 minutes */
+            $accum30mc = \DB::table('bowhead_ohlc_15m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last30timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->orderBy('ctime', 'desc')
+                ->limit(1)
+                ->get();
+            foreach ($accum30mc as $accum30c) {
+                $close30 = $accum30c->close;
+            }
+            if ($open30 && $close30 && $low30 && $high30) {
+                $ins = \DB::insert("
             INSERT INTO bowhead_ohlc_30m 
             (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
             VALUES
-            ('$instrument', $timeid, $last_price, $last_price, $last_price, $last_price, $volume)
+            ('$instrument', $timeid, $open30, $high30, $low30, $close30, $volume)
             ON DUPLICATE KEY UPDATE 
             `high`   = CASE WHEN `high` < VALUES(`high`) THEN VALUES(`high`) ELSE `high` END,
             `low`    = CASE WHEN `low` > VALUES(`low`) THEN VALUES(`low`) ELSE `low` END,
             `volume` = VALUES(`volume`),
             `close`  = VALUES(`close`)
         ");
+            }
         }
 
         /** 1h table update **/
+        $open60 = null;
+        $close60 = null;
+        $high60 = null;
+        $low60 = null;
+
         $last60m = \DB::table('bowhead_ohlc_1h')->select(DB::raw('MAX(timeid) AS timeid'))
             ->where('instrument', $bf_pair)
             ->get();
         foreach ($last60m as $last60) {
             $last60timeid = $last60->timeid;
-	    $last60timeid = date("YmdHi", strtotime("+59 minutes", strtotime($last60timeid)));
+            $last60timeid = date("YmdHi", strtotime("+59 minutes", strtotime($last60timeid)));
         }
         if ($last60timeid < $timeid) {
-            $ins = \DB::insert("
+            /* Get High and Low from 30m data for insertion */
+            $last60timeids = date("YmdHi", strtotime("-60 minutes", strtotime("now")));
+            $accum60ma = \DB::table('bowhead_ohlc_30m')->select(DB::raw('MAX(high) as high, MIN(low) as low'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last60timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->get();
+
+            foreach ($accum60ma as $accum60a) {
+                $high60 = $accum60a->high;
+                $low60 = $accum60a->low;
+            }
+
+            /* Get Open price from 30m data and last 60 minutes */
+            $accum60mb = \DB::table('bowhead_ohlc_30m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last60timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->limit(1)
+                ->get();
+            foreach ($accum60mb as $accum60b) {
+                $open60 = $accum60b->open;
+            }
+
+            /* Get Close price from 30m data and last 60 minutes */
+            $accum60mc = \DB::table('bowhead_ohlc_30m')->select(DB::raw('*'))
+                ->where('instrument', $bf_pair)
+                ->where('timeid', '>=', $last60timeids)
+                ->where('timeid', '<=', ($timeid))
+                ->orderBy('ctime', 'desc')
+                ->limit(1)
+                ->get();
+            foreach ($accum60mc as $accum60c) {
+                $close60 = $accum60c->close;
+            }
+            if ($open60 && $close60 && $low60 && $high60) {
+                $ins = \DB::insert("
             INSERT INTO bowhead_ohlc_1h 
             (`instrument`, `timeid`, `open`, `high`, `low`, `close`, `volume`)
             VALUES
-            ('$instrument', $timeid, $last_price, $last_price, $last_price, $last_price, $volume)
+            ('$instrument', $timeid, $open60, $high60, $low60, $close60, $volume)
             ON DUPLICATE KEY UPDATE 
             `high`   = CASE WHEN `high` < VALUES(`high`) THEN VALUES(`high`) ELSE `high` END,
             `low`    = CASE WHEN `low` > VALUES(`low`) THEN VALUES(`low`) ELSE `low` END,
             `volume` = VALUES(`volume`),
             `close`  = VALUES(`close`)
         ");
+            }
         }
 
         return true;

--- a/app/Traits/OHLC.php
+++ b/app/Traits/OHLC.php
@@ -452,27 +452,26 @@ trait OHLC
 	foreach ($a as $ab) {
 	   #echo print_r($ab,1);
 	   $array = (array) $ab;
-	   $ftime = $array['buckettime'];	
+	   $ftime = $array['buckettime'];
 	   if ($ptime == null) {
 	      $ptime = $ftime;
 	   } else {
 	 	/** Check for missing periods **/
-		if ($periodsize = '1m') {
-		   $variance = (int)60;
-		} else if ($periodsize = '5m') {
-		   $variance = (int)300;
-		} else if ($periodsize = '15m') {
-		   $variance = (int)900;
-		} else if ($periodsize = '30m') {
-		   $variance = (int)1800;
-		} else if ($periodsize = '1h') {
-		   $variance = (int)3600;
-		} else if ($periodsize = '1d') {
-		   $variance = (int)86400;
+		if ($periodSize == '1m') {
+		   $variance = (int)75;
+		} else if ($periodSize == '5m') {
+		   $variance = (int)375;
+		} else if ($periodSize == '15m') {
+		   $variance = (int)1125;
+		} else if ($periodSize == '30m') {
+		   $variance = (int)2250;
+		} else if ($periodSize == '1h') {
+		   $variance = (int)4500;
+		} else if ($periodSize == '1d') {
+		   $variance = (int)108000;
 		}
 		#echo 'Past Time is '.$ptime.' and current time is '.$ftime."\n";
 		$periodcheck = $ptime - $ftime;
-		$variance = 1.5 * $variance;
 		if ((int)$periodcheck > (int)$variance) {
 		echo 'YOU HAVE '.$validperiods.' PERIODS OF VALID PRICE DATA OUT OF '.$limit.'. Please ensure price sync is running and wait for additional data to be logged before trying again. Additionally you could use a smaller time period if available.'."\n";
 		die();


### PR DESCRIPTION
FYI still testing this .. but this adds a new ticker table (you'll need to import the new .sql file in Scripts. Also added to the regular sql script for new users) and tracks the tick data from the websocket to that table. I then made modifications to accumulate the data from the previous smaller increments to create the time frames with proper open, close, high and low.

For example the 5m OHLC table update now looks at the 1m table for immediate previous 5 minutes of data and pulls the highest high and lowest low, and uses the 1st entry for open price, and last entry for close price.

This results in a more accurate time period as one would expect it.

As mentioned still testing and allowing data to build up please let me know if you think there needs to be any changes or other consideration here.