### PR TITLE
FxStreamCommand json encodes ticker

### DIFF
--- a/app/Console/Commands/FxStreamCommand.php
+++ b/app/Console/Commands/FxStreamCommand.php
@@ -68,7 +68,7 @@ class FxStreamCommand extends Command
                 $ticker['tick']['bid'] = round(((float) $fx->Bid + (float) $fx->Ask) / 2, 5);
                 $ticker['tick']['instrument'] = $symbol;
 
-                $this->markOHLC(json_encode($ticker));
+                $this->markOHLC($ticker);
 
                 $ins = $ticker['tick']['instrument'];
                 $curr[$ins] = $ticker['tick']['bid'];

--- a/app/Traits/OHLC.php
+++ b/app/Traits/OHLC.php
@@ -29,6 +29,7 @@ trait OHLC
             $timeid = ($ticker['timeid'] ?? $timeid);
         } else {
             /** Oanda websocket */
+            $ticker = json_decode($ticker, true);
             $last_price = $ticker['tick']['bid'];
             $instrument = $ticker['tick']['instrument'];
             $volume = 0;

--- a/app/Traits/OHLC.php
+++ b/app/Traits/OHLC.php
@@ -29,7 +29,6 @@ trait OHLC
             $timeid = ($ticker['timeid'] ?? $timeid);
         } else {
             /** Oanda websocket */
-            $ticker = json_decode($ticker, true);
             $last_price = $ticker['tick']['bid'];
             $instrument = $ticker['tick']['instrument'];
             $volume = 0;


### PR DESCRIPTION
Oanda ticker item is encoded to JSON string, but used as an associative array in OHLC-Trait.