### PR TITLE
Change Nonce in Bitfinex Api

### DIFF
--- a/app/Util/Bitfinex.php
+++ b/app/Util/Bitfinex.php
@@ -286,7 +286,7 @@ class Bitfinex{
 
    private function headers($data)
    {
-      $data["nonce"] = strval(round(microtime(true) * 1000,0));
+      $data["nonce"] = strval(round(microtime(true) * 10000,0));
       $payload = base64_encode(json_encode($data));
       $signature = hash_hmac("sha384", $payload, $this->secret);
       return array(

--- a/app/Util/Bitfinex.php
+++ b/app/Util/Bitfinex.php
@@ -286,7 +286,7 @@ class Bitfinex{
 
    private function headers($data)
    {
-      $data["nonce"] = strval(round(microtime(true) * 10,0));
+      $data["nonce"] = strval(round(microtime(true) * 1000,0));
       $payload = base64_encode(json_encode($data));
       $signature = hash_hmac("sha384", $payload, $this->secret);
       return array(


### PR DESCRIPTION
Hi, I get "Nonce is too small." when I try to get balance in Bitfinex (using rest API).
Changing the nonce from   
`$data["nonce"] = strval(round(microtime(true) * 10,0));`
to  
`$data["nonce"] = strval(round(microtime(true) * 10000,0));`
solved the problem

Others bot had the same problem: https://github.com/BitBotFactory/poloniexlendingbot/issues/470