### PR TITLE
Fix small mapper Whaleclub typo

### DIFF
--- a/app/Traits/Mapper.php
+++ b/app/Traits/Mapper.php
@@ -174,7 +174,7 @@ trait Mapper
     public function mapperAccounts($source, $data)
     {
        switch ($source) {
-           case 'Whateclub':
+           case 'Whaleclub':
                $instance = new Whaleclub('BTC/USD');
                break;
            case 'OneBroker':


### PR DESCRIPTION
This effectively fixes nothing, because the switch default case caught
the source never matching `Whateclub`. But still...

Having these keys in constants might be a good idea. What would be a central place to put them in?